### PR TITLE
Update Makefile

### DIFF
--- a/trunk/user/tcpdump/Makefile
+++ b/trunk/user/tcpdump/Makefile
@@ -37,7 +37,6 @@ configure:
 		--without-smi \
 		--without-cap-ng \
 		--disable-smb \
-		$(if $(CONFIG_IPV6),--enable-ipv6,--disable-ipv6) \
 		--host=$(HOST_TARGET) \
 		--build=$(HOST_BUILD) ; \
 	)


### PR DESCRIPTION
to fix compile error - unrecognized options: --enable-ipv6
```
configure: WARNING: unrecognized options: --enable-ipv6
make[3]: Leaving directory '/home/mxu/Downloads/src/github.com/hanwckf/rt-n56u/trunk/user/tcpdump'
make[2]: Leaving directory '/home/mxu/Downloads/src/github.com/hanwckf/rt-n56u/trunk/user/tcpdump'
make[1]: *** [Makefile:214: all] Error 2
make[1]: Leaving directory '/home/mxu/Downloads/src/github.com/hanwckf/rt-n56u/trunk/user'
make: *** [Makefile:202: user_only] Error 2
```