### PR TITLE
kernel: fix rtwifi error log

### DIFF
--- a/trunk/proprietary/rt_wifi/rtpci/4.1.X.X/mt76x3/ap/ap_sync.c
+++ b/trunk/proprietary/rt_wifi/rtpci/4.1.X.X/mt76x3/ap/ap_sync.c
@@ -81,7 +81,7 @@ VOID APPeerProbeReqAction(
 
 
 	if (PeerProbeReqSanity(pAd, Elem->Msg, Elem->MsgLen, &ProbeReqParam) == FALSE) {
-DBGPRINT(RT_DEBUG_OFF, ("%s():shiang! PeerProbeReqSanity failed!\n", __FUNCTION__));
+DBGPRINT(RT_DEBUG_TRACE, ("%s():shiang! PeerProbeReqSanity failed!\n", __FUNCTION__));
 		return;
 	}
 

--- a/trunk/proprietary/rt_wifi/rtpci/4.1.X.X/mt76x3/common/cmm_sanity.c
+++ b/trunk/proprietary/rt_wifi/rtpci/4.1.X.X/mt76x3/common/cmm_sanity.c
@@ -221,7 +221,7 @@ BOOLEAN PeerAddBARspActionSanity(
 
 	if (pAddFrame->BaParm.BAPolicy != IMMED_BA)
 	{
-		DBGPRINT(RT_DEBUG_ERROR,("%s(): ADDBA Resp Ba Policy[%d] not support\n", __FUNCTION__, pAddFrame->BaParm.BAPolicy));
+		DBGPRINT(RT_DEBUG_TRACE,("%s(): ADDBA Resp Ba Policy[%d] not support\n", __FUNCTION__, pAddFrame->BaParm.BAPolicy));
 		return FALSE;
 	}
 

--- a/trunk/proprietary/rt_wifi/rtpci/5.0.4.0/mt7615/embedded/ap/ap_sync.c
+++ b/trunk/proprietary/rt_wifi/rtpci/5.0.4.0/mt7615/embedded/ap/ap_sync.c
@@ -90,7 +90,7 @@ VOID APPeerProbeReqAction(
 #endif /* WDS_SUPPORT */
 
 	if (PeerProbeReqSanity(pAd, Elem->Msg, Elem->MsgLen, &ProbeReqParam) == FALSE) {
-		MTWF_LOG(DBG_CAT_AP, DBG_SUBCAT_ALL, DBG_LVL_OFF, ("%s():shiang! PeerProbeReqSanity failed!\n", __func__));
+		MTWF_LOG(DBG_CAT_AP, DBG_SUBCAT_ALL, DBG_LVL_TRACE, ("%s():shiang! PeerProbeReqSanity failed!\n", __func__));
 		return;
 	}
 

--- a/trunk/proprietary/rt_wifi/rtpci/5.0.4.0/mt7615/embedded/common/cmm_sanity.c
+++ b/trunk/proprietary/rt_wifi/rtpci/5.0.4.0/mt7615/embedded/common/cmm_sanity.c
@@ -215,7 +215,7 @@ BOOLEAN PeerAddBARspActionSanity(
 	pAddFrame->TimeOutValue = cpu2le16(pAddFrame->TimeOutValue);
 
 	if (pAddFrame->BaParm.BAPolicy != IMMED_BA) {
-		MTWF_LOG(DBG_CAT_MLME, DBG_SUBCAT_ALL, DBG_LVL_ERROR, ("%s(): ADDBA Resp Ba Policy[%d] not support\n", __func__, pAddFrame->BaParm.BAPolicy));
+		MTWF_LOG(DBG_CAT_MLME, DBG_SUBCAT_ALL, DBG_LVL_TRACE, ("%s(): ADDBA Resp Ba Policy[%d] not support\n", __func__, pAddFrame->BaParm.BAPolicy));
 		return FALSE;
 	}
 


### PR DESCRIPTION
following error appears in the log for a period of time:

kernel: PeerAddBARspActionSanity(): ADDBA Resp Ba Policy[0] not support
kernel: PeerAddBARspActionSanity(): ADDBA Resp Ba Policy[0] not support
...

found a similar fixed in version 4.4.2.1 & 5.0.3.0
commit id: ead23ffe5d1110bdbb630fd1c4afbff11ea9d94b