### PR TITLE
Update Makefile

### DIFF
--- a/trunk/tools/Makefile
+++ b/trunk/tools/Makefile
@@ -36,7 +36,7 @@ go_build:
 	curl --create-dirs -L https://gomirrors.org/dl/go/go$(go_version).linux-amd64.tar.gz -o $(THISDIR)/go/go$(go_version).linux-amd64.tar.gz ; \
 	fi )
 	( if [ ! -d $(THISDIR)/go/go ]; then \
-	tar zxfv $(THISDIR)/go/go$(go_version).linux-amd64.tar.gz -C go ; \
+	tar xfv $(THISDIR)/go/go$(go_version).linux-amd64.tar.gz -C go ; \
 	fi )
 
 clean:


### PR DESCRIPTION
--------------------------MAKE-ALL--------------------------------
make -C tools
make[1]: Entering directory '/opt/rt-n56u/trunk/tools'
mkdir -p /opt/rt-n56u/trunk/tools/go
( if [ ! -f /opt/rt-n56u/trunk/tools/go/go1.15.2.linux-amd64.tar.gz ]; then \
curl --create-dirs -L https://gomirrors.org/dl/go/go1.15.2.linux-amd64.tar.gz -o /opt/rt-n56u/trunk/tools/go/go1.15.2.linux-amd64.tar.gz ; \
fi )
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100    11  100    11    0     0     12      0 --:--:-- --:--:-- --:--:--    12

  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100   114  100   114    0     0     92      0  0:00:01  0:00:01 --:--:--  1187
( if [ ! -d /opt/rt-n56u/trunk/tools/go/go ]; then \
tar zxfv /opt/rt-n56u/trunk/tools/go/go1.15.2.linux-amd64.tar.gz -C go ; \
fi )

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
make[1]: *** [Makefile:36: go_build] Error 2
make[1]: Leaving directory '/opt/rt-n56u/trunk/tools'
make: *** [Makefile:177: tools] Error 2